### PR TITLE
Update inode.c

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -85,7 +85,7 @@ static int init_inodecache(void)
 	ncp_inode_cachep = kmem_cache_create("ncp_inode_cache",
 					     sizeof(struct ncp_inode_info),
 					     0, (SLAB_RECLAIM_ACCOUNT|
-						SLAB_MEM_SPREAD|SLAB_ACCOUNT),
+						SLAB_ACCOUNT),
 					     init_once);
 	if (ncp_inode_cachep == NULL)
 		return -ENOMEM;


### PR DESCRIPTION
mm, slab: remove last vestiges of SLAB_MEM_SPREAD

Yes, yes, I know the slab people were planning on going slow and letting every subsystem fight this thing on their own.  But let's just rip off the band-aid and get it over and done with.  I don't want to see a number of unnecessary pull requests just to get rid of a flag that no longer has any meaning.

This was mainly done with a couple of 'sed' scripts and then some manual cleanup of the end result.