### PR TITLE
ncpfs: modernize mount path and fix fs_context teardown issues

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -614,7 +614,12 @@ ncp_fill_cache(struct file *file, struct dir_context *ctx,
 
 	qname.name = __name;
 
-	newdent = d_hash_and_lookup(dentry, &qname);
+	newdent = d_lookup(dentry, &qname);
+
+	/* d_lookup() increments dentry refcount if found.
+	 * This matches expected semantics of the old d_hash_and_lookup().
+	 */
+
 	if (IS_ERR(newdent))
 		goto end_advance;
 	if (!newdent) {

--- a/dir.c
+++ b/dir.c
@@ -84,7 +84,7 @@ const struct inode_operations ncp_dir_inode_operations =
  * Parent inode i_mutex must be held over d_lookup and into this call (to
  * keep renames and concurrent inserts, and readdir(2) away).
  */
-void new_dentry_update_name_case(struct dentry *, const struct qstr *)
+void new_dentry_update_name_case(struct dentry *dentry, const struct qstr *name)
 {
 	BUG_ON(!inode_is_locked(dentry->d_parent->d_inode));
 	BUG_ON(dentry->d_name.len != name->len); /* d_lookup gives this */

--- a/inode.c
+++ b/inode.c
@@ -27,7 +27,7 @@
 #include <linux/slab.h>
 #include <linux/vmalloc.h>
 #include <linux/init.h>
-#include <linux/vfs.h>
+#include <linux/fs.h>
 #include <linux/mount.h>
 #include <linux/seq_file.h>
 #include <linux/sched/signal.h>
@@ -113,7 +113,7 @@ static const struct super_operations ncp_sops =
 {
 	.alloc_inode	= ncp_alloc_inode,
 	.destroy_inode	= ncp_destroy_inode,
-	.drop_inode	= generic_delete_inode,
+	.drop_inode	= inode_generic_drop,
 	.evict_inode	= ncp_evict_inode,
 	.put_super	= ncp_put_super,
 	.statfs		= ncp_statfs,

--- a/inode.c
+++ b/inode.c
@@ -51,6 +51,7 @@ static void ncp_put_super(struct super_block *);
 static int  ncp_statfs(struct dentry *, struct kstatfs *);
 static int  ncp_show_options(struct seq_file *, struct dentry *);
 static int  ncp_fill_super(struct super_block *sb, struct fs_context *fc);
+static void delayed_free(struct rcu_head *p);
 
 static struct kmem_cache * ncp_inode_cachep;
 
@@ -320,6 +321,7 @@ static void ncp_stop_tasks(struct ncp_server *server) {
 	sk->sk_error_report = server->error_report;
 	sk->sk_data_ready   = server->data_ready;
 	sk->sk_write_space  = server->write_space;
+	sk->sk_user_data    = NULL;
 	release_sock(sk);
 	timer_delete_sync(&server->timeout_tm);
 
@@ -753,7 +755,7 @@ out_fput:
 out:
 	put_pid(data.wdog_pid);
 	sb->s_fs_info = NULL;
-	kfree(server);
+	call_rcu(&server->rcu, delayed_free);
 	return error;
 }
 
@@ -1035,10 +1037,9 @@ static int ncp_parse_monolithic(struct fs_context *fc, void *data)
 static void ncp_free_fc(struct fs_context *fc)
 {
 	/*
-	 * For legacy mount(2), the VFS passes the monolithic data page here.
-	 * We only keep the pointer long enough for ->get_tree().
+	 * For legacy mount(2), the VFS owns the monolithic mount-data
+	 * buffer. Do not free fc->fs_private here.
 	 */
-	kfree(fc->fs_private);
 }
 
 static int ncp_get_tree(struct fs_context *fc)

--- a/inode.c
+++ b/inode.c
@@ -1023,7 +1023,7 @@ out:
 static struct dentry *ncp_mount(struct file_system_type *fs_type,
 	int flags, const char *dev_name, void *data)
 {
-	return mount_nodev(fs_type, flags, data, ncp_fill_super);
+	return ncp_mount_nodev(fs_type, flags, data, ncp_fill_super);
 }
 
 static struct file_system_type ncp_fs_type = {

--- a/inode.c
+++ b/inode.c
@@ -30,6 +30,7 @@
 #include <linux/fs.h>
 #include <linux/statfs.h>
 #include <linux/mount.h>
+#include <linux/fs_context.h>
 #include <linux/seq_file.h>
 #include <linux/sched/signal.h>
 #include <linux/namei.h>
@@ -49,6 +50,7 @@ static void ncp_evict_inode(struct inode *);
 static void ncp_put_super(struct super_block *);
 static int  ncp_statfs(struct dentry *, struct kstatfs *);
 static int  ncp_show_options(struct seq_file *, struct dentry *);
+static int  ncp_fill_super(struct super_block *sb, struct fs_context *fc);
 
 static struct kmem_cache * ncp_inode_cachep;
 
@@ -103,10 +105,12 @@ static void destroy_inodecache(void)
 	kmem_cache_destroy(ncp_inode_cachep);
 }
 
-static int ncp_remount(struct super_block *sb, int *flags, char* data)
+static int ncp_reconfigure(struct fs_context *fc)
 {
+	struct super_block *sb = fc->root->d_sb;
 	sync_filesystem(sb);
-	*flags |= SB_NODIRATIME;
+	fc->sb_flags |= SB_NODIRATIME;
+	fc->sb_flags_mask |= SB_NODIRATIME;
 	return 0;
 }
 
@@ -118,7 +122,6 @@ static const struct super_operations ncp_sops =
 	.evict_inode	= ncp_evict_inode,
 	.put_super	= ncp_put_super,
 	.statfs		= ncp_statfs,
-	.remount_fs	= ncp_remount,
 	.show_options	= ncp_show_options,
 };
 
@@ -465,8 +468,10 @@ err:
 	return ret;
 }
 
-static int ncp_fill_super(struct super_block *sb, void *raw_data, int silent)
+static int ncp_fill_super(struct super_block *sb, struct fs_context *fc)
 {
+	void *raw_data = fc->fs_private;
+	int silent = !!(fc->sb_flags & SB_SILENT);
 	struct ncp_mount_data_kernel data;
 	struct ncp_server *server;
 	struct inode *root_inode;
@@ -1021,16 +1026,43 @@ out:
 	return result;
 }
 
-static struct dentry *ncp_mount(struct file_system_type *fs_type,
-	int flags, const char *dev_name, void *data)
+static int ncp_parse_monolithic(struct fs_context *fc, void *data)
 {
-	return ncp_mount_nodev(fs_type, flags, data, ncp_fill_super);
+	fc->fs_private = data;
+	return 0;
+}
+
+static void ncp_free_fc(struct fs_context *fc)
+{
+	/*
+	 * For legacy mount(2), the VFS passes the monolithic data page here.
+	 * We only keep the pointer long enough for ->get_tree().
+	 */
+	kfree(fc->fs_private);
+}
+
+static int ncp_get_tree(struct fs_context *fc)
+{
+	return get_tree_nodev(fc, ncp_fill_super);
+}
+
+static const struct fs_context_operations ncp_context_ops = {
+	.free		= ncp_free_fc,
+	.parse_monolithic = ncp_parse_monolithic,
+	.get_tree	= ncp_get_tree,
+	.reconfigure	= ncp_reconfigure,
+};
+
+static int ncp_init_fs_context(struct fs_context *fc)
+{
+	fc->ops = &ncp_context_ops;
+	return 0;
 }
 
 static struct file_system_type ncp_fs_type = {
 	.owner		= THIS_MODULE,
 	.name		= "ncpfs",
-	.mount		= ncp_mount,
+	.init_fs_context = ncp_init_fs_context,
 	.kill_sb	= kill_anon_super,
 	.fs_flags	= FS_BINARY_MOUNTDATA,
 };

--- a/inode.c
+++ b/inode.c
@@ -28,6 +28,7 @@
 #include <linux/vmalloc.h>
 #include <linux/init.h>
 #include <linux/fs.h>
+#include <linux/statfs.h>
 #include <linux/mount.h>
 #include <linux/seq_file.h>
 #include <linux/sched/signal.h>

--- a/inode.c
+++ b/inode.c
@@ -1063,3 +1063,5 @@ static void __exit exit_ncp_fs(void)
 module_init(init_ncp_fs)
 module_exit(exit_ncp_fs)
 MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Johannes C. Schulz (EnzephaloN) <info@enzephalon.de>");
+MODULE_DESCRIPTION("NCP file system support to mount NetWare volumes");

--- a/ncp_fs.h
+++ b/ncp_fs.h
@@ -104,4 +104,7 @@ int ncp_mmap(struct file *, struct vm_area_struct *);
 /* linux/fs/ncpfs/ncplib_kernel.c */
 int ncp_make_closed(struct inode *);
 
+extern struct dentry *ncp_mount_nodev(struct file_system_type *,
+       int, void *, int (*fill_super)(struct super_block *, void *, int));
+
 #include "ncplib_kernel.h"

--- a/ncplib_kernel.c
+++ b/ncplib_kernel.c
@@ -14,6 +14,25 @@
 
 #include "ncp_fs.h"
 
+struct dentry *ncp_mount_nodev(struct file_system_type *fs_type,
+       int flags, void *data,
+       int (*fill_super)(struct super_block *, void *, int))
+{
+       int error;
+       struct super_block *s = sget(fs_type, NULL, set_anon_super, flags, NULL);
+
+       if (IS_ERR(s))
+               return ERR_CAST(s);
+
+       error = fill_super(s, data, flags & SB_SILENT ? 1 : 0);
+       if (error) {
+               deactivate_locked_super(s);
+               return ERR_PTR(error);
+       }
+       s->s_flags |= SB_ACTIVE;
+       return dget(s->s_root);
+}
+
 static inline void assert_server_locked(struct ncp_server *server)
 {
 	if (server->lock == 0) {


### PR DESCRIPTION
This series updates ncpfs to current kernel interfaces by:
- replacing removed/deprecated VFS helpers
- adding a nodev mount helper
- converting mount handling to fs_context
- fixing teardown and error-path invalid frees
- adding small metadata/header cleanups